### PR TITLE
Fix PyPI workflow to fetch git tags for proper version detection

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for setuptools-scm to detect version from tags
       
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -42,7 +44,13 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build twine setuptools-scm
+      
+      - name: Verify version detection
+        run: |
+          DETECTED_VERSION=$(python -m setuptools_scm)
+          echo "Version detected by setuptools-scm: $DETECTED_VERSION"
+          git describe --tags
       
       - name: Build package
         run: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing to PyPI, focusing on ensuring correct version detection using `setuptools-scm`. The main improvements are in how the workflow checks out code and verifies the version before building the package.

**Workflow improvements for version detection:**

* The `actions/checkout` step now uses `fetch-depth: 0` to ensure the full git history is available, which is required for `setuptools-scm` to detect the version from tags.
* The build dependencies installation now includes `setuptools-scm`, enabling version detection from git tags.

**New version verification step:**

* Added a step to verify the detected version by running `python -m setuptools_scm` and displaying the result, along with the output of `git describe --tags`, to confirm the versioning setup before building the package.