### PR TITLE
Release/0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0] - 2025-10-28
 
 ### Added
-- Nothing yet
+- Timestamped log files with automatic cleanup of old logs
+- Log file location displayed in output when verbose mode is off
+
+### Changed
+- **BREAKING**: Minimum Python version raised from 3.8 to 3.10
+- **BREAKING**: Removed `--skip-existing` flag from extraction commands
+- Improved filename handling to reflect specified date ranges in output files
+- Cleaner CLI output with better separation of user messages and technical logs
+- Enhanced date handling for more consistent database time conversions
+
+### Fixed
+- Release versioning and tagging workflow issues
 
 ## [0.1.0] - 2025-10-27
 


### PR DESCRIPTION
This pull request updates the `CHANGELOG.md` to document the upcoming `0.2.0` release, outlining several new features, breaking changes, and improvements. The most important changes are the introduction of timestamped log files with automatic cleanup, enhancements to log file visibility, and key breaking changes such as raising the minimum Python version and removing a command-line flag.

New features and enhancements:

* Added timestamped log files with automatic cleanup of old logs.
* Log file location is now displayed in output when verbose mode is off.
* Improved filename handling to reflect specified date ranges in output files.
* Cleaner CLI output with better separation of user messages and technical logs.
* Enhanced date handling for more consistent database time conversions.

Breaking changes:

* Minimum Python version requirement raised from 3.8 to 3.10.
* Removed the `--skip-existing` flag from extraction commands.

Bug fixes:

* Fixed release versioning and tagging workflow issues.