### PR TITLE
Fix release pipeline error by updating `twine check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
     
     - name: Check package
       run: |
-        twine check dist/*
+        twine check dist/*.whl dist/*.tar.gz
     
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       
       - name: Verify package integrity
         run: |
-          twine check dist/*
+          twine check dist/*.whl dist/*.tar.gz
       
       - name: Submit SBOM to Dependency Graph
         uses: evryfs/sbom-dependency-submission-action@v0.0.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Nothing yet
+### Fixed
+- Release pipeline error where `twine check` attempted to validate SBOM JSON files as Python distributions
 
 ## [0.5.0] - 2025-11-06
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -290,7 +290,7 @@ git push origin v0.0.1
 ```bash
 # Test build locally first
 python -m build
-twine check dist/*
+twine check dist/*.whl dist/*.tar.gz
 ```
 
 ### Wrong Version After Release


### PR DESCRIPTION
This pull request fixes an issue in the release pipeline where `twine check` was incorrectly validating SBOM JSON files as Python distributions. The updates ensure that only valid Python package files are checked, improving the reliability of the build and release workflows.

**Release and CI workflow improvements:**

* Updated `twine check` commands in `.github/workflows/ci.yml` and `.github/workflows/release.yml` to only validate `.whl` and `.tar.gz` files, preventing errors from checking non-package files. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL146-R146) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L78-R78)
* Updated documentation in `docs/RELEASING.md` to reflect the corrected usage of `twine check`.

**Changelog update:**

* Added a changelog entry in `CHANGELOG.md` describing the fixed release pipeline error related to `twine check`.