### PR TITLE
Add non-blocking security audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,30 @@ jobs:
       run: |
         ruff format --check src/ tests/
 
+  security-audit:
+    name: Security Audit (pip-audit)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e '.[dev]'
+    
+    - name: Audit dependencies
+      run: |
+        pip-audit --desc
+
   test-ubuntu:
     name: Ubuntu - Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint format type-check check test clean install dev coverage build sbom validate-pyproject
+.PHONY: help lint format type-check check test clean install dev coverage build sbom validate-pyproject security-audit
 
 help:
 	@echo "Available commands:"
@@ -13,6 +13,7 @@ help:
 	@echo "  make check               - Run all checks (lint + format + validate + tests)"
 	@echo "  make test                - Run tests"
 	@echo "  make coverage            - Run tests with coverage report"
+	@echo "  make security-audit      - Run security audit on dependencies"
 	@echo "  make build               - Build wheel distribution package"
 	@echo "  make sbom                - Generate SBOM (Software Bill of Materials)"
 	@echo "  make clean               - Remove build artifacts and cache files"
@@ -70,6 +71,10 @@ coverage:
 	./venv/bin/pytest --cov=src/phasor_point_cli --cov-report=term-missing --cov-report=html
 	@echo ""
 	@echo "HTML coverage report generated in htmlcov/index.html"
+
+security-audit:
+	@echo "Running security audit on dependencies..."
+	./venv/bin/pip-audit --desc
 
 sbom:
 	@echo "Generating SBOM (Software Bill of Materials)..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "setuptools-scm>=8.0",
     "validate-pyproject>=0.15",
     "cyclonedx-bom>=4.0.0",
+    "pip-audit>=2.6.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This pull request introduces a security audit workflow to the project, making it easier to detect vulnerable dependencies both locally and in CI. The main changes add the `pip-audit` tool to the development dependencies, integrate it into the `Makefile`, and set up a corresponding GitHub Actions job.

**Security audit integration:**

* Added a new `security-audit` job to `.github/workflows/ci.yml` that runs `pip-audit` to check for vulnerable dependencies during CI runs. This job is marked as `continue-on-error: true` so it won't fail the workflow if issues are found.
* Added `pip-audit>=2.6.0` to the `dev` dependencies list in `pyproject.toml` to ensure the tool is available in development environments.

**Makefile enhancements:**

* Added a `security-audit` target to the `Makefile`, allowing developers to run `make security-audit` to check dependencies locally.
* Updated the `.PHONY` targets and help text in the `Makefile` to include `security-audit` and document its usage. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R16)